### PR TITLE
Addition of msg.payload.addtoheatmap and msg.payload.intensity

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Optional properties include
  - **iconColor** : Standard CSS color name or #rrggbb hex value.
  - **photoUrl** : adds an image pointed at by the url to the popup box.
  - **deleted** : set to <i>true</i> to remove the named marker. (default false)
+ - **addtoheatmap** : set to <i>false</i> to exlcude point from adding to heatmap layer. (default true)
+ - **int** : set to a value of 0.1 - 1.0 to set the intensity of the point on heatmap layer. (default 1.0)
+  
 
 Any other `msg.payload` properties will be added to the icon popup text box.
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Optional properties include
  - **iconColor** : Standard CSS color name or #rrggbb hex value.
  - **photoUrl** : adds an image pointed at by the url to the popup box.
  - **deleted** : set to <i>true</i> to remove the named marker. (default false)
- - **addtoheatmap** : set to <i>false</i> to exlcude point from adding to heatmap layer. (default true)
- - **int** : set to a value of 0.1 - 1.0 to set the intensity of the point on heatmap layer. (default 1.0)
+ - **addtoheatmap** : set to <i>false</i> to exlcude point from contributing to heatmap layer. (default true)
+ - **intensity** : set to a value of 0.1 - 1.0 to set the intensity of the point on heatmap layer. (default 1.0)
   
 
 Any other `msg.payload` properties will be added to the icon popup text box.

--- a/worldmap/index.html
+++ b/worldmap/index.html
@@ -777,7 +777,7 @@ function setMarker(data) {
         else { console.log("No location:",data); return; }
         // Adding new L.LatLng object (lli) when optional intensity value is defined. Only for use in heatmap layer
         if (typeof data.coordinates == "object") { lli = new L.LatLng(data.coordinates[2],data.coordinates[1],data.coordinates[0]); }
-        else if (data.hasOwnProperty("lat") && data.hasOwnProperty("lon") && data.hasOwnProperty("int")) { lli = new L.LatLng((data.lat*1), (data.lon*1), (data.int*1)); }
+        else if (data.hasOwnProperty("lat") && data.hasOwnProperty("lon") && data.hasOwnProperty("intensity")) { lli = new L.LatLng((data.lat*1), (data.lon*1), (data.intensity*1)); }
         else if (data.hasOwnProperty("latitude") && data.hasOwnProperty("longitude") && data.hasOwnProperty("intensity")) { lli = new L.LatLng((data.latitude*1), (data.longitude*1), (data.intensity*1)); }
         else { lli = ll }
 

--- a/worldmap/index.html
+++ b/worldmap/index.html
@@ -712,8 +712,9 @@ var delMarker = function(dname) {
 
 // the MAIN add something to map function
 function setMarker(data) {
-    console.log(typeof data, data);
+    //console.log(typeof data, data);
     var ll;
+    var lli = null;
     var stay = popped;
 
     var lay = data.layer || "not known";
@@ -774,6 +775,12 @@ function setMarker(data) {
         else if (data.hasOwnProperty("lat") && data.hasOwnProperty("lon")) { ll = new L.LatLng((data.lat*1), (data.lon*1)); }
         else if (data.hasOwnProperty("latitude") && data.hasOwnProperty("longitude")) { ll = new L.LatLng((data.latitude*1), (data.longitude*1)); }
         else { console.log("No location:",data); return; }
+        // Adding new L.LatLng object (lli) when optional intensity value is defined. Only for use in heatmap layer
+        if (typeof data.coordinates == "object") { lli = new L.LatLng(data.coordinates[2],data.coordinates[1],data.coordinates[0]); }
+        else if (data.hasOwnProperty("lat") && data.hasOwnProperty("lon") && data.hasOwnProperty("int")) { lli = new L.LatLng((data.lat*1), (data.lon*1), (data.int*1)); }
+        else if (data.hasOwnProperty("latitude") && data.hasOwnProperty("longitude") && data.hasOwnProperty("intensity")) { lli = new L.LatLng((data.latitude*1), (data.longitude*1), (data.intensity*1)); }
+        else { lli = ll }
+
         var words="<b>"+data.name+"</b><br/>";
 
         // Create the icons... handle ship, earthquake as specials
@@ -889,8 +896,9 @@ function setMarker(data) {
                 rightmenuMarker.setLatLng(e.latlng);
                 map.openPopup(rightmenuMarker);
             });
-
-            if (heatAll || map.hasLayer(layers[lay])) { heat.addLatLng(ll); }
+            if ((data.addtoheatmap !== "false") || (!data.hasOwnProperty("addtoheatmap"))){ // Added to give ability to control if points from active layer contribute to heatmap
+  				if (heatAll || map.hasLayer(layers[lay])) { heat.addLatLng(lli); }	
+            }
             markers[data.name] = marker;
             layers[lay].addLayer(marker);
         }


### PR DESCRIPTION
To summarize.

- added `msg.payload.addtoheatmap`. This defaults to true so you need to explicitly set it to false if you dont want that point to contribute to the heatmap. Done to make this change non breaking for other users.
- added `msg.payload.intensity`. This sets the intensity of the point you contribute to the heatmap. If you leave the heatmap max parameter at the default of 1 it will work with values of 0.1 - 1.0 
if this parameter doesn't exist the current behavior as it stands today is applied.

Notes
there is a bug in leaflet-heat at the moment that if you change max parameter of the heatmap the intensity value doesn't work correctly (screws up when you zoom in and out). suggest leaving at default of 1 and scaling intensity between 0.1 - 1.