### PR TITLE
Host Error

### DIFF
--- a/examples/Map in Dashboard.json
+++ b/examples/Map in Dashboard.json
@@ -57,7 +57,7 @@
         "z": "5ab56e5e.449a5",
         "name": "",
         "topic": "",
-        "payload": "/red/worldmap",
+        "payload": "/worldmap",
         "payloadType": "str",
         "repeat": "",
         "crontab": "",


### PR DESCRIPTION
The inject node with "/red/worldmap" as payload should be only "/worldmap" since that is the url where the map is.

 Same thing apply in the function node before the worldmap node in the following line of the json object (url field) ->
 msg.payload={lat:lat, lon:lon, name:"Mike", icon:"male", url:"<a href=\"/ui/#/1\">IBM link</a>"};
It should be without the "/red" part but I didnt fix it because I dont understand the purporse of it, since it would be a infinite loop of links.