### PR TITLE
allow the icon of GPX overlay markers to be chosen

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ As per the geojson overlay you can also inject a KML layer or TOPOJSON layer. Th
         kml:"<kml>...your kml placemarks...</kml>"
     };
 
+
+ For GPX layers, it is possible to define which icon to use for point markers by adding the
+ following properties to `msg.payload.command.map`:
+ - **icon** : <a href="http://fortawesome.github.io/Font-Awesome/icons/" target="mapinfo">font awesome</a> icon name.
+ - **iconColor** : Standard CSS colour name or #rrggbb hex value.
+
 Again the `fit` property can be added to make the map zoom to the relevant area.
 
 #### To add a Velocity Grid Overlay

--- a/worldmap/index.html
+++ b/worldmap/index.html
@@ -1268,7 +1268,23 @@ function doCommand(cmd) {
             map.removeLayer(overlays[cmd.map.overlay]);
             existsalready = true;
         }
-        overlays[cmd.map.overlay] = omnivore.gpx.parse(cmd.map.gpx);
+
+        var customLayer = L.geoJson();
+        if (cmd.map.hasOwnProperty("icon")) {
+            var col = cmd.map.iconColor || "#910000";
+            var myMarker = L.divIcon({
+                className:"faicon",
+                html: '<center><i class="fa fa-fw '+cmd.map.icon+'" style="color:'+col+'"></i></center>',
+                iconSize: [15, 15],
+            });
+            customLayer = L.geoJson(null, {
+                pointToLayer: function(geoJsonPoint, latlng) {
+                    return L.marker(latlng, {icon: myMarker, title: geoJsonPoint.properties.name});
+                }
+            });
+        }
+        overlays[cmd.map.overlay] = omnivore.gpx.parse(cmd.map.gpx, null, customLayer);
+
         if (!existsalready) {
             layercontrol.addOverlay(overlays[cmd.map.overlay],cmd.map.overlay);
         }


### PR DESCRIPTION
This pull requests allows the icons used to mark GPX overlay points to be defined in the command.map payload sent to the worldmap. The icon can use any fa-awesome icon and the iconColor can be set as well. IMHO this entire section of kml/gpx/geojson import should be refactored to use the parser to generate geojson from kml or gpx (which happens under the hood anyway), and then separately allow options to be applied to the result. This way the same options would be available for all 3 types of imports.