### PR TITLE
Center on object only if center property set

### DIFF
--- a/worldmap/index.html
+++ b/worldmap/index.html
@@ -1769,7 +1769,7 @@ function doCommand(cmd) {
         document.getElementById("heatall").checked = !!cmd.heatmap;
         heat.redraw();
     }
-    map.setView([clat,clon],czoom);
+    if (cmd.hasOwnProperty("center")) map.setView([clat,clon],czoom);
 }
 
 // handle any incoming GEOJSON directly - may style badly


### PR DESCRIPTION
Currently map centers on every object drawing.
This eliminates the last map center save option....
normal use case is draw all objects after 'connect'  event, map center restore however is done on map object initialization.
This change centers the map on new object only if 'center' property is added to the object properties.  