### PR TITLE
disable ui_worldmap if Node-RED Dashboard not installed

### DIFF
--- a/worldmap.html
+++ b/worldmap.html
@@ -359,75 +359,82 @@ then by default <code>⌘⇧m</code> - <code>ctrl-shift-m</code> will load the m
         }
     });
 
-    RED.nodes.registerType('ui_worldmap',{
-        category: 'dashboard',
-        color: 'rgb( 63, 173, 181)',
-        defaults: {
-            group: {type: 'ui_group', required:true},
-            order: {value: 0},
-            width: {
-                value: 0,
-                validate: function(v) {
-                    var valid = true
-                    var width = v||0;
-                    var currentGroup = $('#node-input-group').val()|| this.group;
-                    var groupNode = RED.nodes.node(currentGroup);
-                    valid = !groupNode || +width <= +groupNode.width;
-                    $("#node-input-size").toggleClass("input-error",!valid);
-                    return valid;
-                }},
-            height: {value: 0},
-            name: {value:""},
-            lat: {value:""},
-            lon: {value:""},
-            zoom: {value:""},
-            layer: {value:""},
-            cluster: {value:""},
-            maxage: {value:""},
-            usermenu: {value:"hide"},
-            layers: {value:"hide"},
-            panit: {value:"false"},
-            panlock: {value:"false"},
-            zoomlock: {value:"false"},
-            hiderightclick: {value:"true"},
-            coords: {value:"false"},
-            showgrid: {value:"false"},
-            path: {value:"/worldmap"}
-        },
-        inputs:1,
-        outputs:0,
-        icon: "white-globe.png",
-        align: "right",
-        paletteLabel: "worldmap",
-        label: function() {
-            return this.name||(this.path.charAt(0)==='/'?this.path.substr(1):this.path)||"world map";
-        },
-        labelStyle: function() {
-            return this.name?"node_label_italic":"";
-        },
-        info: function() {
-            return 'The map can also be found [here]('+RED.settings.httpNodeRoot.slice(0,-1)+this.path+').';
-        },
-        oneditprepare: function() {
-            $("#node-input-size").elementSizer({
-                width: "#node-input-width",
-                height: "#node-input-height",
-                group: "#node-input-group"
+    $.get('/.ui-worldmap', function (data) {
+        if (data === "true") {
+            RED.nodes.registerType('ui_worldmap',{
+                category: 'dashboard',
+                color: 'rgb( 63, 173, 181)',
+                defaults: {
+                    group: {type: 'ui_group', required:true},
+                    order: {value: 0},
+                    width: {
+                        value: 0,
+                        validate: function(v) {
+                            var valid = true
+                            var width = v||0;
+                            var currentGroup = $('#node-input-group').val()|| this.group;
+                            var groupNode = RED.nodes.node(currentGroup);
+                            valid = !groupNode || +width <= +groupNode.width;
+                            $("#node-input-size").toggleClass("input-error",!valid);
+                            return valid;
+                        }},
+                    height: {value: 0},
+                    name: {value:""},
+                    lat: {value:""},
+                    lon: {value:""},
+                    zoom: {value:""},
+                    layer: {value:""},
+                    cluster: {value:""},
+                    maxage: {value:""},
+                    usermenu: {value:"hide"},
+                    layers: {value:"hide"},
+                    panit: {value:"false"},
+                    panlock: {value:"false"},
+                    zoomlock: {value:"false"},
+                    hiderightclick: {value:"true"},
+                    coords: {value:"false"},
+                    showgrid: {value:"false"},
+                    path: {value:"/worldmap"}
+                },
+                inputs:1,
+                outputs:0,
+                icon: "white-globe.png",
+                align: "right",
+                paletteLabel: "worldmap",
+                label: function() {
+                    return this.name||(this.path.charAt(0)==='/'?this.path.substr(1):this.path)||"world map";
+                },
+                labelStyle: function() {
+                    return this.name?"node_label_italic":"";
+                },
+                info: function() {
+                    return 'The map can also be found [here]('+RED.settings.httpNodeRoot.slice(0,-1)+this.path+').';
+                },
+                oneditprepare: function() {
+                    $("#node-input-size").elementSizer({
+                        width: "#node-input-width",
+                        height: "#node-input-height",
+                        group: "#node-input-group"
+                    });
+                    if ($("#node-input-path").val() === undefined) {
+                        $("#node-input-path").val("worldmap");
+                        this.path = "worldmap";
+                    }
+                    if ($("#node-input-hiderightclick").val() === null) {
+                        $("#node-input-hiderightclick").val("false");
+                        this.hiderightclick = "false";
+                    }
+                    if ($("#node-input-coords").val() === null) {
+                        $("#node-input-coords").val("none");
+                        this.coords = "none";
+                    }
+                    $("#node-input-zoom").spinner({min:0, max:18});
+                    $("#node-input-cluster").spinner({min:0, max:19});
+                }
             });
-            if ($("#node-input-path").val() === undefined) {
-                $("#node-input-path").val("worldmap");
-                this.path = "worldmap";
-            }
-            if ($("#node-input-hiderightclick").val() === null) {
-                $("#node-input-hiderightclick").val("false");
-                this.hiderightclick = "false";
-            }
-            if ($("#node-input-coords").val() === null) {
-                $("#node-input-coords").val("none");
-                this.coords = "none";
-            }
-            $("#node-input-zoom").spinner({min:0, max:18});
-            $("#node-input-cluster").spinner({min:0, max:19});
+        }
+        else {
+            console.log("ui_worldmap: Node-RED not found.");
         }
     });
 </script>


### PR DESCRIPTION
Hi. Thank you for merging `ui_worldmap`.
This PR add capability to disable `ui_worldmap` node if Node-RED Dashboard is not installed.
Because I can not find a way to check installation of Node-RED Dashboard from client-side, I introduced runtime API to check availability of dashboard.
