### PR TITLE
Allow the icon URL to be only a full path

### DIFF
--- a/worldmap/worldmap.js
+++ b/worldmap/worldmap.js
@@ -1793,7 +1793,7 @@ function setMarker(data) {
             marker = L.marker(ll, {title:data.name, icon:myMarker, draggable:drag});
             labelOffset = [12,-4];
         }
-        else if (data.icon.match(/^https?:.*$/)) {
+        else if (data.icon.match(/^https?:.*$|^\//)) {
             var sz = data.iconSize ?? 32;
             myMarker = L.icon({
                 iconUrl: data.icon,


### PR DESCRIPTION
The Node-RED flow does not know the protocol, host and port that the client is using.  (It could be proxied, for a start.)  Because of this, if the icons are on the Node-RED server itself, it's hard to create the URL for the marker icon.  This very simple change allows the URL to be a full path (beginning with a slash) with the assumption that it's on the same server as the map.  Such a URL can be passed to Leaflet and is (in my tests) rendered correctly.