### PR TITLE
Update README.md - Optional properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,13 +422,15 @@ Optional properties include
  - **zoomlock** - locks the zoom control to the current value and removes zoom control - `{"command":{"zoomlock":true}}`
  - **hiderightclick** - disables the right click that allows adding or deleting points on the map - `{"command":{"hiderightclick":true}}`
  - **coords** - turns on and off a display of the current mouse co-ordinates. Values can be "deg", "dms", or "none" (default). - `{"command":{"coords":"deg"}}`
- - **showruler** - turns on and off a display of the ruler control. Values can be "true" or "false". - `{"command":{"showruler":true}}`
+ - **showruler** - turns on and off a display of the ruler control. Values can be "true" or "false". - `{"command": {"ruler": {"showruler": true}}}`
  - **button** - if supplied with a `name` and `icon` property - adds a button to provide user input - sends
  a msg `{"action":"button", "name":"the_button_name"}` to the worldmap in node. If supplied with a `name` property only, it will remove the button. Optional `position` property can be 'bottomright', 'bottomleft', 'topleft' or 'topright' (default). button can also be an array of button objects.
  - **contextmenu** - html string to define the right click menu when not on a marker. Defaults to the simple add marker input. Empty string `""` disables this right click.
  - **toptitle** - Words to replace title in title bar (if not in iframe)
  - **toplogo** - URL to logo image for top tile bar (if not in iframe) - ideally 60px by 24px.
  - **trackme** - Turns on/off the browser self locating. Boolean false = off, true = cyan circle showing accuracy error, or an object like `{"command":{"trackme":{"name":"Dave","icon":"car","iconColor":"blue","layer":"mytrack","accuracy":false}}}`. Usual marker options can be applied. 
+ - **showmenu** - Show or hide the display of the hamberger menu control in the top right . Values can be "show" or "hide". - `{"command":{"showmenu: "hide"}}`
+ - **showlayers** - Show or hide the display of selectable layers. Does not control the display of an individual layer, rather a users ability to interact with them. Values can be "show" or "hide". - `{"command":{"showlayers: "hide"}}`
 
 #### To switch layer, move map and zoom
 


### PR DESCRIPTION
Documentation states:
```
showruler - turns on and off a display of the ruler control. Values can be "true" or "false". - {"command":{"showruler":true}}
```

The command is wrong its missing key 'ruler'
see RedMap/worldmap/worldmap.js line 2280-2281:
```
if (cmd.hasOwnProperty("ruler")) {
        if (cmd.ruler.hasOwnProperty("showruler")) {
```

Also, some Optional properties that users can use were not described in the documentation.

Added showmenu and showlayers so users can know about the functionality