### PR TITLE
Update worldmap.js - add clientTimezone

### DIFF
--- a/worldmap/worldmap.js
+++ b/worldmap/worldmap.js
@@ -63,7 +63,7 @@ var connect = function() {
         if (!inIframe) {
             document.getElementById("footer").innerHTML = "<font color='#494'>"+pagefoot+"</font>";
         }
-        ws.send(JSON.stringify({action:"connected",parameters:Object.fromEntries((new URL(location)).searchParams)}));
+        ws.send(JSON.stringify({action:"connected",parameters:Object.fromEntries((new URL(location)).searchParams),clientTimezone:Intl.DateTimeFormat().resolvedOptions().timeZone || false}));
         onoffline();
     };
     ws.onclose = function() {


### PR DESCRIPTION
Add clientTimezone to the 'connected' msg.payload

If unable to complete query return bool of 'false'

Why? 
Many clients connect to the world map from different locals. Knowing what time their browser/computer is using allows us to format events to their timezone.

Overhead is minimal as it only is queried once when they connect.