### PR TITLE
Optional send on click

### DIFF
--- a/worldmap/worldmap.js
+++ b/worldmap/worldmap.js
@@ -1510,7 +1510,8 @@ function setMarker(data) {
         m.on('click', function(e) {
             var fb = allData[data["name"]];
             fb.action = "click";
-            ws.send(JSON.stringify(fb));
+            if (fb.sendOnClick ?? true)
+                ws.send(JSON.stringify(fb));
         });
         // customise right click context menu
         var rightcontext = "";


### PR DESCRIPTION
Currently, the map sends all entity data with every click, which could result in transmitting a large amount of data, especially if popups and context menus include HTML. Since most entities are created by the backend, this data is often unnecessary. To maintain backward compatibility, the default should be to preserve the current behavior. Additionally, an optional setting should be introduced; if set to false, it will disable the data transmission on click.






