### PR TITLE
Add multiple coordinats display

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,30 +13,30 @@ Feel free to [![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%
 
 ### Updates
 
-- v4.7.0  - Update pmtiles library, fix feedback function inconsistency. Issue #270
-- v4.6.5  - Let geojson allow for generic overrides with .icon and .layer.
-- v4.6.4  - Fix deletion of layers logic to actually fully remove points.
-- v4.6.3  - Fix sending of layer events when not wanted. Issue #262
-- v4.6.2  - Fix multiple use of contextmenu feedback. Issue #259
-- v4.6.1  - Let default pmtiles be light/dark or monocolored.
-- v4.5.2  - Tidy up when pmtiles removed.
-- v4.5.0  - Fix pmtiles to look for maps in userdir rather than modules
-- v4.4.0  - Add quad(copter) drone icon.
-- v4.3.3  - Fix for objects changing layers.
-- v4.3.2  - Fix geojson popup missing label name.
-- v4.3.1  - Small fix to icon transparency, and routing detail.
-- v4.3.0  - Add support for PMtiles files.
-- v4.2.1  - Revert use of optional chaining to extend life slightly. Issue #252
-- v4.2.0  - Let icons also be inline images data:image... 
-- v4.1.0  - Add optional SOG, COG, altft, altm input properties.
-- v4.0.0  - Breaking - Better context menu variable substitution and retention
-            Now uses ${name} syntax rather than $name so we can handle user defined variables in context menus.
-- v3.2.0  - Sync up drawing sessions across browsers to same map
-- v3.1.0  - Add esri overlay layers, and let geojson overlay rendering be customised
-- v3.0.0  - Bump to Leaflet 1.9.4
-            Breaking - Move to geoman for drawing shapes.
-            Allow command.rotation to set rotation of map.
-            Allow editing of multipoint geojson tracks.
+- v4.7.0 - Update pmtiles library, fix feedback function inconsistency. Issue #270
+- v4.6.5 - Let geojson allow for generic overrides with .icon and .layer.
+- v4.6.4 - Fix deletion of layers logic to actually fully remove points.
+- v4.6.3 - Fix sending of layer events when not wanted. Issue #262
+- v4.6.2 - Fix multiple use of contextmenu feedback. Issue #259
+- v4.6.1 - Let default pmtiles be light/dark or monocolored.
+- v4.5.2 - Tidy up when pmtiles removed.
+- v4.5.0 - Fix pmtiles to look for maps in userdir rather than modules
+- v4.4.0 - Add quad(copter) drone icon.
+- v4.3.3 - Fix for objects changing layers.
+- v4.3.2 - Fix geojson popup missing label name.
+- v4.3.1 - Small fix to icon transparency, and routing detail.
+- v4.3.0 - Add support for PMtiles files.
+- v4.2.1 - Revert use of optional chaining to extend life slightly. Issue #252
+- v4.2.0 - Let icons also be inline images data:image...
+- v4.1.0 - Add optional SOG, COG, altft, altm input properties.
+- v4.0.0 - Breaking - Better context menu variable substitution and retention
+  Now uses ${name} syntax rather than $name so we can handle user defined variables in context menus.
+- v3.2.0 - Sync up drawing sessions across browsers to same map
+- v3.1.0 - Add esri overlay layers, and let geojson overlay rendering be customised
+- v3.0.0 - Bump to Leaflet 1.9.4
+  Breaking - Move to geoman for drawing shapes.
+  Allow command.rotation to set rotation of map.
+  Allow editing of multipoint geojson tracks.
 
 - see [CHANGELOG](https://github.com/dceejay/RedMap/blob/master/CHANGELOG.md) for full list of changes.
 
@@ -61,31 +61,31 @@ The minimum **msg.payload** must contain `name`, `lat` and `lon` properties, for
 
 Optional properties for **msg.payload** include
 
- - **deleted** : set to <i>true</i> to remove the named marker. (default <i>false</i>)
- - **draggable** : set to <i>true</i> to allow marker to be moved by the mouse. (default <i>false</i>)
- - **layer** : specify a layer on the map to add marker to. (default <i>"unknown"</i>)
- - **track | hdg | heading | COG | bearing** : when combined with speed, draws a vector. (only first will be used)
- - **speed** : when combined with track, hdg, heading, or bearing, draws a leader line vector - should be in m/s. Can also be specified as "20 kph", or "20 mph", or "20 kt". i.e a string with units.
- - **SOG** : speed over ground - speed in knots.
- - **alt | altitude | altft | altm** : Altitude in meters, but can use *altft* to specify feet instead.
- - **accuracy** : when combined with heading vector, draws an arc of possible direction.
- - **color** : CSS color name or #rrggbb value for heading vector line or accuracy polygon.
- - **icon** : <a href="https://fontawesome.com/v4.7.0/icons/" target="mapinfo">font awesome</a> icon name, <a href="https://github.com/Paul-Reed/weather-icons-lite" target="mapinfo">weather-lite</a> icon, :emoji name:, or https:// or inline data:image/ uri.
- - **iconColor** : Standard CSS colour name or #rrggbb hex value.
- - **SIDC** : NATO symbology code (can be used instead of icon). See below.
- - **building** : OSMbulding GeoJSON feature set to add 2.5D buildings to buildings layer. See below.
- - **ttl** : time to live, how long an individual marker stays on map in seconds (overrides general maxage setting, minimum 20 seconds)
- - **photoUrl** : adds an image pointed at by the url to the popup box.
- - **videoUrl** : adds an mp4 video pointed at by the url to the popup box. Ideally 320x240 in size.
- - **weblink** : adds a link to an external page. Either set a url as a *string*, or an *object* like `{"name":"BBC News", "url":"https://news.bbc.co.uk", "target":"_new"}`, or multiple links with an *array of objects* `[{"name":"BBC News", "url":"https://news.bbc.co.uk", "target":"_new"},{"name":"node-red", "url":"https://nodered.org", "target":"_new"}]`
- - **addtoheatmap** : set to <i>false</i> to exclude point from contributing to the heatmap layer. (default true)
- - **intensity** : set to a value of 0.1 - 1.0 to set the intensity of the point on the heatmap layer. (default 1.0)
- - **clickable** : Default true. Setting to false disables showing any popup.
- - **popped** : set to true to automatically open the popup info box, set to false to close it.
- - **popup** : html to fill the popup if you don't want the automatic default of the properties list. Using this overrides photourl, videourl and weblink options.
- - **label** : displays the contents as a permanent label next to the marker, or
- - **tooltip** : displays the contents when you hover over the marker. (Mutually exclusive with label. Label has priority)
- - **contextmenu** : an html fragment to display on right click of marker - defaults to delete marker. You can specify `${name}` to substitute in the name of the marker. Set to `""` to disable just this instance.
+- **deleted** : set to <i>true</i> to remove the named marker. (default <i>false</i>)
+- **draggable** : set to <i>true</i> to allow marker to be moved by the mouse. (default <i>false</i>)
+- **layer** : specify a layer on the map to add marker to. (default <i>"unknown"</i>)
+- **track | hdg | heading | COG | bearing** : when combined with speed, draws a vector. (only first will be used)
+- **speed** : when combined with track, hdg, heading, or bearing, draws a leader line vector - should be in m/s. Can also be specified as "20 kph", or "20 mph", or "20 kt". i.e a string with units.
+- **SOG** : speed over ground - speed in knots.
+- **alt | altitude | altft | altm** : Altitude in meters, but can use _altft_ to specify feet instead.
+- **accuracy** : when combined with heading vector, draws an arc of possible direction.
+- **color** : CSS color name or #rrggbb value for heading vector line or accuracy polygon.
+- **icon** : <a href="https://fontawesome.com/v4.7.0/icons/" target="mapinfo">font awesome</a> icon name, <a href="https://github.com/Paul-Reed/weather-icons-lite" target="mapinfo">weather-lite</a> icon, :emoji name:, or https:// or inline data:image/ uri.
+- **iconColor** : Standard CSS colour name or #rrggbb hex value.
+- **SIDC** : NATO symbology code (can be used instead of icon). See below.
+- **building** : OSMbulding GeoJSON feature set to add 2.5D buildings to buildings layer. See below.
+- **ttl** : time to live, how long an individual marker stays on map in seconds (overrides general maxage setting, minimum 20 seconds)
+- **photoUrl** : adds an image pointed at by the url to the popup box.
+- **videoUrl** : adds an mp4 video pointed at by the url to the popup box. Ideally 320x240 in size.
+- **weblink** : adds a link to an external page. Either set a url as a _string_, or an _object_ like `{"name":"BBC News", "url":"https://news.bbc.co.uk", "target":"_new"}`, or multiple links with an _array of objects_ `[{"name":"BBC News", "url":"https://news.bbc.co.uk", "target":"_new"},{"name":"node-red", "url":"https://nodered.org", "target":"_new"}]`
+- **addtoheatmap** : set to <i>false</i> to exclude point from contributing to the heatmap layer. (default true)
+- **intensity** : set to a value of 0.1 - 1.0 to set the intensity of the point on the heatmap layer. (default 1.0)
+- **clickable** : Default true. Setting to false disables showing any popup.
+- **popped** : set to true to automatically open the popup info box, set to false to close it.
+- **popup** : html to fill the popup if you don't want the automatic default of the properties list. Using this overrides photourl, videourl and weblink options.
+- **label** : displays the contents as a permanent label next to the marker, or
+- **tooltip** : displays the contents when you hover over the marker. (Mutually exclusive with label. Label has priority)
+- **contextmenu** : an html fragment to display on right click of marker - defaults to delete marker. You can specify `${name}` to substitute in the name of the marker. Set to `""` to disable just this instance.
 
 Any other `msg.payload` properties will be added to the icon popup text box. This can be
 overridden by using the **popup** property to supply your own html content. If you use the
@@ -98,29 +98,29 @@ If you use the name without the fa- prefix (eg `male`) you will get the icon ins
 
 You can also specify an emoji as the icon by using the :emoji name: syntax - for example `:smile:`. Here is a **[list of emojis](https://github.com/dceejay/RedMap/blob/master/emojilist.md)**.
 
-Or you can specify an image to load as an icon by setting the icon to `http(s)://...` By default it will be scaled to 32x32 pixels. You can change the size by setting **iconSize** to a number - eg 64. Example icon - `"https://img.icons8.com/windows/32/000000/bird.png"`  or you can use an inline image of the form `data:image/...`  which uses a base64 encoded image.
+Or you can specify an image to load as an icon by setting the icon to `http(s)://...` By default it will be scaled to 32x32 pixels. You can change the size by setting **iconSize** to a number - eg 64. Example icon - `"https://img.icons8.com/windows/32/000000/bird.png"` or you can use an inline image of the form `data:image/...` which uses a base64 encoded image.
 
 There are also several special icons...
 
- - **plane** : a jet plane icon that aligns with the heading of travel.
- - **smallplane** : a light aircraft icon that aligns with the heading of travel.
- - **ship** : a ship icon that aligns with the heading of travel.
- - **car** : a car icon that aligns with the heading of travel.
- - **bus** : a bus/coach icon that aligns with the heading of travel.
- - **uav** : a small drone uav like icon that aligns with the heading of travel.
- - **quad** : a small quadcopter uav like icon that aligns with the heading of travel.
- - **helicopter** : a small helicopter icon that aligns with the heading of travel.
- - **sensor** : a camera icon that points to the heading angle.
- - **arrow** : a map GPS arrow type pointer that aligns with the heading of travel.
- - **wind** : a wind arrow that points in the direction the wind is coming FROM.
- - **satellite** : a small satellite icon.
- - **iss** : a slightly larger icon for the ISS.
- - **locate** : a 4 corner outline to locate a point without obscuring it.
- - **friend** : pseudo NATO style blue rectangle. (but see NATO SIDC option below)
- - **hostile** : pseudo NATO style red circle.
- - **neutral** : pseudo NATO style green square.
- - **unknown** : pseudo NATO style yellow square.
- - **earthquake** : black circle - diameter proportional to `msg.mag`.
+- **plane** : a jet plane icon that aligns with the heading of travel.
+- **smallplane** : a light aircraft icon that aligns with the heading of travel.
+- **ship** : a ship icon that aligns with the heading of travel.
+- **car** : a car icon that aligns with the heading of travel.
+- **bus** : a bus/coach icon that aligns with the heading of travel.
+- **uav** : a small drone uav like icon that aligns with the heading of travel.
+- **quad** : a small quadcopter uav like icon that aligns with the heading of travel.
+- **helicopter** : a small helicopter icon that aligns with the heading of travel.
+- **sensor** : a camera icon that points to the heading angle.
+- **arrow** : a map GPS arrow type pointer that aligns with the heading of travel.
+- **wind** : a wind arrow that points in the direction the wind is coming FROM.
+- **satellite** : a small satellite icon.
+- **iss** : a slightly larger icon for the ISS.
+- **locate** : a 4 corner outline to locate a point without obscuring it.
+- **friend** : pseudo NATO style blue rectangle. (but see NATO SIDC option below)
+- **hostile** : pseudo NATO style red circle.
+- **neutral** : pseudo NATO style green square.
+- **unknown** : pseudo NATO style yellow square.
+- **earthquake** : black circle - diameter proportional to `msg.mag`.
 
 #### NATO Symbology
 
@@ -146,7 +146,6 @@ Users of [TAK](https://tak.gov) can use the [TAK ingest node](https://flows.node
 ![Tak Flow](https://github.com/dceejay/pages/blob/master/TAKflow.png?raw=true)
 ![Tak Image](https://github.com/dceejay/pages/blob/master/TAKicons.png?raw=true)
 
-
 ### Areas, Rectangles, Lines, and GreatCircles
 
 If the msg.payload contains an **area** property - that is an array of co-ordinates, e.g.
@@ -169,15 +168,14 @@ Shapes can also have a **popup** property containing html, but you MUST also set
 
 There are extra optional properties you can specify - see Options below.
 
-
 ### Circles and Ellipses
 
 If the msg.payload contains a **radius** property, as well as name, lat and lon, then rather
-than draw a point it will draw a circle. The *radius* property is specified in meters.
+than draw a point it will draw a circle. The _radius_ property is specified in meters.
 
     msg.payload = { "name":"A3090", "lat":51.05, "lon":-1.35, "radius":3000 }
 
-As per Areas and Lines you may also specify *color*, *fillColor*, and *layer*, see Options section below.
+As per Areas and Lines you may also specify _color_, _fillColor_, and _layer_, see Options section below.
 
     msg.payload =  {
         "name": "circle",
@@ -196,7 +194,6 @@ of an ellipse, in meters. A **tilt** property can also be applied to rotate the 
 a number of degrees.
 
     msg.payload = { "name":"Bristol Channel", "lat":51.5, "lon":-2.9, "radius":[30000,70000], "tilt":45 };
-
 
 ### Arcs, Range Rings
 
@@ -226,25 +223,25 @@ Defaults are shown above.
 
 There are several ways to send GeoJSON to the map.
 
-1) If the msg.payload contains a **geojson** property, and no **lat** and **lon**, then
-rather than draw a point it will render the geojson.
+1.  If the msg.payload contains a **geojson** property, and no **lat** and **lon**, then
+    rather than draw a point it will render the geojson.
 
-    msg.payload = {
-        "name": "MyPolygon",
-        "geojson": {
-            "type": "Feature",
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [[[-180,10],[20,90],[180,-5],[-30,-90]]]
-            },
-            "style": {
-                "stroke-width": "8",
-                "stroke": "#ff00ff",
-                "fill-color": "#808000",
-                "fill-opacity": 0.2
+        msg.payload = {
+            "name": "MyPolygon",
+            "geojson": {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[-180,10],[20,90],[180,-5],[-30,-90]]]
+                },
+                "style": {
+                    "stroke-width": "8",
+                    "stroke": "#ff00ff",
+                    "fill-color": "#808000",
+                    "fill-opacity": 0.2
+                }
             }
         }
-    }
 
 Often geojson may not have a `properties` or `style` property in which case you can specify some global optional properties (see below) in order to set some defaults for the geojson object.
 
@@ -261,44 +258,41 @@ Often geojson may not have a `properties` or `style` property in which case you 
         clickable: true
     }
 
-2) You can just send a msg.payload containing the geojson itself - but obviously you then can't style it, set the name, layer, etc.
+2. You can just send a msg.payload containing the geojson itself - but obviously you then can't style it, set the name, layer, etc.
 
-3) You can also add the geojson as a specific overlay, in which case you can also have more control of styles, and per feature customisations. See the section on overlays [below](#to-add-a-new-geojson-overlay). This is the most complex but also the most customisable.
-
+3. You can also add the geojson as a specific overlay, in which case you can also have more control of styles, and per feature customisations. See the section on overlays [below](#to-add-a-new-geojson-overlay). This is the most complex but also the most customisable.
 
 ### Options
 
 Areas, Rectangles, Lines, Circles and Ellipses can also specify more optional properties:
 
- - **layer** : declares which layer you put it on.
- - **color** : can set the colour of the polygon or line.
- - **opacity** : the opacity of the line or outline.
- - **fillColor** : can set the fill colour of the polygon.
- - **fillOpacity** : can set the opacity of the polygon fill colour.
- - **dashArray** : optional dash array for polyline.
- - **clickable** : boolean - set to true to allow click to show popup.
- - **popup** : html string to display in popup (as well as name).
- - **editable** : boolean - set to true to allow simple edit/delete right click contextmenu.
- - **tooltip** : Text string to display on mouse hover over the shape.
- - **contextmenu** : html string to display a more complex right click contextmenu.
- - **weight** : the width of the line or outline.
+- **layer** : declares which layer you put it on.
+- **color** : can set the colour of the polygon or line.
+- **opacity** : the opacity of the line or outline.
+- **fillColor** : can set the fill colour of the polygon.
+- **fillOpacity** : can set the opacity of the polygon fill colour.
+- **dashArray** : optional dash array for polyline.
+- **clickable** : boolean - set to true to allow click to show popup.
+- **popup** : html string to display in popup (as well as name).
+- **editable** : boolean - set to true to allow simple edit/delete right click contextmenu.
+- **tooltip** : Text string to display on mouse hover over the shape.
+- **contextmenu** : html string to display a more complex right click contextmenu.
+- **weight** : the width of the line or outline.
 
 Other properties can be found in the leaflet documentation.
 
 Shapes can also have a **popup** property containing html, but you MUST also set a property `clickable:true` in order to allow it to be seen.
 
-
 ### Drawing
 
-A single *right click* will allow you to add a point to the map - you must specify the `name` and optionally the `icon` and `layer`.
+A single _right click_ will allow you to add a point to the map - you must specify the `name` and optionally the `icon` and `layer`.
 
 Right-clicking on an icon will allow you to delete it.
 
 If you select the **drawing** layer you can also add and edit polylines, polygons, rectangles and circles.
-Once an item is drawn you can right click to edit or delete it. 
+Once an item is drawn you can right click to edit or delete it.
 
 Double click the object to exit edit mode.
-
 
 ### Buildings
 
@@ -336,7 +330,7 @@ as per the OSMBuildings spec. For example in a function node:
     msg.payload = {command:{map:m, lat:51.0484, lon:-1.3558}};
     return msg;
 
-**Note**: the object you supply will replace the whole buildings layer. To delete the building send a msg with a name and the building property set to ""  (blank string).
+**Note**: the object you supply will replace the whole buildings layer. To delete the building send a msg with a name and the building property set to "" (blank string).
 
 #### Buildings 3D view
 
@@ -348,22 +342,20 @@ The `icon` can be specified as a person, block, bar, or "anything else" - they w
 
 `msg.payload.icon` can be
 
- - person : 1m x 1m x 2m tall
- - block : 5m x 5m x 5m cube
- - bar : a bar from the surface up to the specified minHeight
- - (else) : 1.5m x 1.5m x 1.5m cube
-
+- person : 1m x 1m x 2m tall
+- block : 5m x 5m x 5m cube
+- bar : a bar from the surface up to the specified minHeight
+- (else) : 1.5m x 1.5m x 1.5m cube
 
 in addition existing male, female, fa-male and fa-female icons are all represented as the person shape.
- `msg.iconColor` can be used to colour the icons.
+`msg.iconColor` can be used to colour the icons.
 
- **NOTES**
+**NOTES**
 
- - There is currently no way to add labels, popups, or to make the icons clickable.
- - The 3D only really works at zoomed in scales 16+ due to the small size of the icons. They are not scale independent like icons on the normal map.
- - As this uses the mapbox api you may wish to edit the index3d.html code to include your api key to remove any usage restrictions.
- - This view is a side project to the Node-RED Worldmap project so I'm happy to take PRs but it probably won't be actively developed.
-
+- There is currently no way to add labels, popups, or to make the icons clickable.
+- The 3D only really works at zoomed in scales 16+ due to the small size of the icons. They are not scale independent like icons on the normal map.
+- As this uses the mapbox api you may wish to edit the index3d.html code to include your api key to remove any usage restrictions.
+- This view is a side project to the Node-RED Worldmap project so I'm happy to take PRs but it probably won't be actively developed.
 
 ## Controlling the map
 
@@ -371,42 +363,42 @@ You can also control the map via the node, by sending in a msg.payload containin
 
 Optional properties for **msg.payload.command** include
 
- - **lat** - move map to specified latitude.
- - **lon** - move map to specified longitude.
- - **zoom** - move map to specified zoom level (1 - world, 13 to 20 max zoom depending on map).
- - **bounds** - if set to an array `[ [ lat(S), lon(W) ], [lat(N), lon(E)] ]` - sets the overall map bounds.
- - **rotation** - rotate the base map to the specified compass angle.
- - **layer** - set map to specified base layer name - `{"command":{"layer":"Esri"}}`
- - **search** - search markers on map for name containing `string`. If not found in existing markers, will then try geocoding looking using Nominatim. An empty string `""` clears the search results. - `{"command":{"search":"Winchester"}}`
- - **showlayer** - show the named overlay(s) - `{"command":{"showlayer":"foo"}}` or `{"command":{"showlayer":["foo","bar"]}}`
- - **hidelayer** - hide the named overlay(s) - `{"command":{"hidelayer":"bar"}}` or `{"command":{"hidelayer":["bar","another"]}}`
- - **side** - add a second map alongside with slide between them. Use the name of a *baselayer* to add - or "none" to remove the control. - `{"command":{"side":"Esri Satellite"}}`
- - **split** - once you have split the screen with the *side* command - the split value is then the % across the screen of the split line. - `{"command":{"split":50}}`
- - **map** - Object containing details of a new map layer:
-   - **name** - name of the map base layer OR **overlay** - name of overlay layer
-   - **url** - url of the map layer
-   - **opt** - options object for the new layer
-   - **wms** - true/false/grey, specifies if the data is provided by a Web Map Service (if grey sets layer to greyscale)
-   - **bounds** - sets the bounds of an Overlay-Image. 2 Dimensional Array that defines the top-left and bottom-right Corners (lat/lon Points)
-   - **delete** - name or array of names of base layers and/or overlays to delete and remove from layer menu.
- - **heatmap** - set heatmap latlngs array object see https://github.com/Leaflet/Leaflet.heat#reference
- - **options** - if heatmap set, then use this to set heatmap options object see https://github.com/Leaflet/Leaflet.heat#reference
- - **clear** - layer name - to clear a complete layer and remove from layer menu - `{"command":{"clear":"myOldLayer"}}`
- - **panlock** - lock the map area to the current visible area. - `{"command":{"panlock":true}}`
- - **panit** - auto pan to the latest marker updated.  - `{"command":{"panit":true}}`
- - **zoomlock** - locks the zoom control to the current value and removes zoom control - `{"command":{"zoomlock":true}}`
- - **hiderightclick** - disables the right click that allows adding or deleting points on the map - `{"command":{"hiderightclick":true}}`
- - **coords** - turns on and off a display of the current mouse co-ordinates. Values can be "deg", "dms", or "none" (default). - `{"command":{"coords":"deg"}}`
- - **showruler** - turns on and off a display of the ruler control. Values can be "true" or "false". - `{"command": {"ruler": {"showruler": true}}}`
- - **button** - if supplied with a `name` and `icon` property - adds a button to provide user input - sends
- a msg `{"action":"button", "name":"the_button_name"}` to the worldmap in node. If supplied with a `name` property only, it will remove the button. Optional `position` property can be 'bottomright', 'bottomleft', 'topleft' or 'topright' (default). button can also be an array of button objects.
- - **contextmenu** - html string to define the right click menu when not on a marker. Defaults to the simple add marker input. Empty string `""` disables this right click.
- - **drawcontextmenu** : an html fragment to display on right click or when creating new shapes (enable Drawing overlay in the worldmap node Overlays selection dropdown) - defaults to "Name" Input "Edit Points|Drag|Rotate|Delete|Ok" buttons.
- - **toptitle** - Words to replace title in title bar (if not in iframe)
- - **toplogo** - URL to logo image for top title bar (if not in iframe) - ideally 60px by 24px.
- - **trackme** - Turns on/off the browser self locating. Boolean false = off, true = cyan circle showing accuracy error, or an object like `{"command":{"trackme":{"name":"Dave","icon":"car","iconColor":"blue","layer":"mytrack","accuracy":false}}}`. Usual marker options can be applied. 
- - **showmenu** - Show or hide the display of the hamberger menu control in the top right . Values can be "show" or "hide". - `{"command":{"showmenu": "hide"}}`
- - **showlayers** - Show or hide the display of selectable layers. Does not control the display of an individual layer, rather a users ability to interact with them. Values can be "show" or "hide". - `{"command":{"showlayers": "hide"}}`
+- **lat** - move map to specified latitude.
+- **lon** - move map to specified longitude.
+- **zoom** - move map to specified zoom level (1 - world, 13 to 20 max zoom depending on map).
+- **bounds** - if set to an array `[ [ lat(S), lon(W) ], [lat(N), lon(E)] ]` - sets the overall map bounds.
+- **rotation** - rotate the base map to the specified compass angle.
+- **layer** - set map to specified base layer name - `{"command":{"layer":"Esri"}}`
+- **search** - search markers on map for name containing `string`. If not found in existing markers, will then try geocoding looking using Nominatim. An empty string `""` clears the search results. - `{"command":{"search":"Winchester"}}`
+- **showlayer** - show the named overlay(s) - `{"command":{"showlayer":"foo"}}` or `{"command":{"showlayer":["foo","bar"]}}`
+- **hidelayer** - hide the named overlay(s) - `{"command":{"hidelayer":"bar"}}` or `{"command":{"hidelayer":["bar","another"]}}`
+- **side** - add a second map alongside with slide between them. Use the name of a _baselayer_ to add - or "none" to remove the control. - `{"command":{"side":"Esri Satellite"}}`
+- **split** - once you have split the screen with the _side_ command - the split value is then the % across the screen of the split line. - `{"command":{"split":50}}`
+- **map** - Object containing details of a new map layer:
+  - **name** - name of the map base layer OR **overlay** - name of overlay layer
+  - **url** - url of the map layer
+  - **opt** - options object for the new layer
+  - **wms** - true/false/grey, specifies if the data is provided by a Web Map Service (if grey sets layer to greyscale)
+  - **bounds** - sets the bounds of an Overlay-Image. 2 Dimensional Array that defines the top-left and bottom-right Corners (lat/lon Points)
+  - **delete** - name or array of names of base layers and/or overlays to delete and remove from layer menu.
+- **heatmap** - set heatmap latlngs array object see https://github.com/Leaflet/Leaflet.heat#reference
+- **options** - if heatmap set, then use this to set heatmap options object see https://github.com/Leaflet/Leaflet.heat#reference
+- **clear** - layer name - to clear a complete layer and remove from layer menu - `{"command":{"clear":"myOldLayer"}}`
+- **panlock** - lock the map area to the current visible area. - `{"command":{"panlock":true}}`
+- **panit** - auto pan to the latest marker updated. - `{"command":{"panit":true}}`
+- **zoomlock** - locks the zoom control to the current value and removes zoom control - `{"command":{"zoomlock":true}}`
+- **hiderightclick** - disables the right click that allows adding or deleting points on the map - `{"command":{"hiderightclick":true}}`
+- **coords** - turns on and off a display of the current mouse co-ordinates. Values can be "deg", "dms", "utm", "mgrs", "qth" or "none" (default). - `{"command":{"coords":"deg"}}` , `{"command":{"coords":"deg,dms,utm"}}`
+- **showruler** - turns on and off a display of the ruler control. Values can be "true" or "false". - `{"command": {"ruler": {"showruler": true}}}`
+- **button** - if supplied with a `name` and `icon` property - adds a button to provide user input - sends
+  a msg `{"action":"button", "name":"the_button_name"}` to the worldmap in node. If supplied with a `name` property only, it will remove the button. Optional `position` property can be 'bottomright', 'bottomleft', 'topleft' or 'topright' (default). button can also be an array of button objects.
+- **contextmenu** - html string to define the right click menu when not on a marker. Defaults to the simple add marker input. Empty string `""` disables this right click.
+- **drawcontextmenu** : an html fragment to display on right click or when creating new shapes (enable Drawing overlay in the worldmap node Overlays selection dropdown) - defaults to "Name" Input "Edit Points|Drag|Rotate|Delete|Ok" buttons.
+- **toptitle** - Words to replace title in title bar (if not in iframe)
+- **toplogo** - URL to logo image for top title bar (if not in iframe) - ideally 60px by 24px.
+- **trackme** - Turns on/off the browser self locating. Boolean false = off, true = cyan circle showing accuracy error, or an object like `{"command":{"trackme":{"name":"Dave","icon":"car","iconColor":"blue","layer":"mytrack","accuracy":false}}}`. Usual marker options can be applied.
+- **showmenu** - Show or hide the display of the hamberger menu control in the top right . Values can be "show" or "hide". - `{"command":{"showmenu": "hide"}}`
+- **showlayers** - Show or hide the display of selectable layers. Does not control the display of an individual layer, rather a users ability to interact with them. Values can be "show" or "hide". - `{"command":{"showlayers": "hide"}}`
 
 #### To switch layer, move map and zoom
 
@@ -476,7 +468,7 @@ By default the overlay will be instantly visible. To load it hidden add a proper
 
 The geojson features may contain a `properties` property. That may also include a `style` with properties - stroke, stroke-width, stroke-opacity, fill, fill-opacity. Any other properties will be listed in the popup.
 
-The `opt` property is optional. See the <a href="https://leafletjs.com/examples/geojson/">Leaflet geojson docs</a> for more info on possible options. 
+The `opt` property is optional. See the <a href="https://leafletjs.com/examples/geojson/">Leaflet geojson docs</a> for more info on possible options.
 
 NOTE: In order to pass over **style**, **pointToLayer**, **onEachFeature**, or **filter** functions they need to be serialised as follows... for example
 
@@ -498,11 +490,11 @@ As with the geojson overlay, you can also inject a KML layer, GPX layer or TOPOJ
         "kml": "<kml>...your kml placemarks...</kml>"
     };
 
- For GPX and KML layers, it is possible to define which icon to use for point markers by adding the
- following properties to `msg.payload.command.map`:
+For GPX and KML layers, it is possible to define which icon to use for point markers by adding the
+following properties to `msg.payload.command.map`:
 
- - **icon** : <a href="https://fontawesome.com/v4.7.0/icons/" target="mapinfo">font awesome</a> icon name.
- - **iconColor** : Standard CSS colour name or #rrggbb hex value.
+- **icon** : <a href="https://fontawesome.com/v4.7.0/icons/" target="mapinfo">font awesome</a> icon name.
+- **iconColor** : Standard CSS colour name or #rrggbb hex value.
 
 Again the boolean `fit` or `fly` properties can be added to make the map zoom to the relevant area, and the `visible` property can be set false to not immediately show the layer.
 
@@ -628,6 +620,7 @@ Example simple form
 See the section on **Utility Functions** for details of the feedback function.
 
 For the drawcontextmenu you can use the following snippet as a template:
+
 ```
 msg.payload  = {"command" :{"drawcontextmenu" :"<input type='text' value='${name}' id='dinput' placeholder='name (,icon, layer)'/><br/><button onclick='editPoly(\"${name}\");'>My Edit points</button><button onclick='editPoly(\"${name}\",\"drag\");'>My Drag</button><button onclick='editPoly(\"${name}\",\"rot\");'>My Rotate</button><button onclick='delMarker(\"${name}\",true);'>My Delete</button><button onclick='sendDrawing();'>My OK</button>"}};
 ```
@@ -656,7 +649,6 @@ valid options from the [minimap library options](https://github.com/Norkart/Leaf
     };
 
 Set `msg.payload.command.map.minimap = false;` to remove the minimap.
-
 
 ## Events from the map
 
@@ -694,16 +686,15 @@ The "connected" action additionally includes a:
 `msg.payload.clientTimezone` property string showing the clients local Timezone. Returns bool of `false` if unable to retrive clients local Timezone.
 `msg._clientheaders` property that shows the headers sent by the client to make a connection to the session.
 
-
 ### Utility functions
 
 There are some internal functions available to make interacting with Node-RED easier (e.g. from inside a user defined popup., these include:
 
- - **feedback()** : it takes 2, 3, or 4 parameters, name, value, and optionally an action name (defaults to "feedback"), and optional boolean to close the popup on calling this function, and can be used inside something like an input tag - `onchange='feedback(this.name,this.value,null,true)'`. Value can be a more complex object if required as long as it is serialisable. If used with a marker the name should be that of the marker - you can use `${name}` to let it be substituted automatically.
+- **feedback()** : it takes 2, 3, or 4 parameters, name, value, and optionally an action name (defaults to "feedback"), and optional boolean to close the popup on calling this function, and can be used inside something like an input tag - `onchange='feedback(this.name,this.value,null,true)'`. Value can be a more complex object if required as long as it is serialisable. If used with a marker the name should be that of the marker - you can use `${name}` to let it be substituted automatically.
 
- - **addToForm()** : takes a property name value pair to add to a variable called `form`. When used with contextmenu feedback (above) you can set the feedback value to `"_form"` to substitute this accumulated value. This allows you to do things like `onBlur='addToForm(this.name,this.value)'` over several different fields in the menu and then use `feedback(this.name,"_form")` to submit them all at once. For example a simple multiple line form could be as per the example below:
+- **addToForm()** : takes a property name value pair to add to a variable called `form`. When used with contextmenu feedback (above) you can set the feedback value to `"_form"` to substitute this accumulated value. This allows you to do things like `onBlur='addToForm(this.name,this.value)'` over several different fields in the menu and then use `feedback(this.name,"_form")` to submit them all at once. For example a simple multiple line form could be as per the example below:
 
- Also if you wish to retain the values between separate openings of this form you can assign property names to the value field in the form `value="${foo}`, etc. These will then appear as part of an **value** property on the worldmap-in node message.
+Also if you wish to retain the values between separate openings of this form you can assign property names to the value field in the form `value="${foo}`, etc. These will then appear as part of an **value** property on the worldmap-in node message.
 
 ```
 var menu = 'Add some data <input name="foo" value="${foo}" onchange=\'addToForm(this.name,this.value)\'></input><br/>'
@@ -712,10 +703,9 @@ menu += '<button name="my_form" onclick=\'feedback(this.name,"_form",null,true)\
 msg.payload = { command: { "contextmenu":menu } }
 ```
 
- - **delMarker()** : takes the name of the marker as a parameter. In a popup this can be specified as `${name}` for dynamic substitution.
+- **delMarker()** : takes the name of the marker as a parameter. In a popup this can be specified as `${name}` for dynamic substitution.
 
- - **editPoly()** : takes the name of the shape or line as a parameter. In a popup this can be specified as `${name}` for dynamic substitution.
-
+- **editPoly()** : takes the name of the shape or line as a parameter. In a popup this can be specified as `${name}` for dynamic substitution.
 
 ## Serving maps
 
@@ -738,7 +728,7 @@ You can set some default options for the pmtiles by creating a file called **pmt
         "theme": "dark"
     }
 
-theme can be light, dark, white, black, or grayscale. 
+theme can be light, dark, white, black, or grayscale.
 
 The `maxDataZoom` should match the maximum zoom level in you pmtiles file(s) - whereas the `maxZoom` is the leaflet maximum zoom level you want to support. `shade` can be any valid html colour or #rrggbb string, and `dark` is a boolean (default false).
 
@@ -751,26 +741,31 @@ Where `opt` can be as per the options file mentioned above - or omitted complete
 ### Using a Docker Map Server
 
 I have found the easiest to use mapserver for a decent generic map to be Tileserver-gl. It uses mbtiles format maps - for example from [MapTiler Data](https://data.maptiler.com/downloads/planet/). You can download your mbtiles file into a directory and then from that directory run
+
 ```
 docker run --name maptiler -d -v $(pwd):/data -p 1884:8080 maptiler/tileserver-gl -p 8080 --mbtiles yourMapFile.mbtiles
 ```
+
 and use a url like `"url": "http://localhost:1884/styles/basic-preview/{z}/{x}/{y}.png"`
 
 Other more traditional map servers include containers like https://hub.docker.com/r/camptocamp/mapserver, then assuming you have the mapfile 'my-app.map' in the current working directory, you could mount it as:
+
 ```
 docker run -d --name camptocamp -v $(pwd):/etc/mapserver/:ro -p 1881:80 camptocamp/mapserver
 ```
 
-then the url should be of the form `"url": "http://localhost:1881/?map=/etc/mapserver/my-app.map"` where *my-app.map* is the name of your map file. A quick test of the server would be to browse to http://localhost:1881/?map=/etc/mapserver/my-app.map&mode=map
+then the url should be of the form `"url": "http://localhost:1881/?map=/etc/mapserver/my-app.map"` where _my-app.map_ is the name of your map file. A quick test of the server would be to browse to http://localhost:1881/?map=/etc/mapserver/my-app.map&mode=map
 
 Or you can use a docker container like https://hub.docker.com/r/geodata/mapserver/ then assuming you have the mapfile 'my-app.map' in the current working directory, you could mount it as:
+
 ```
 docker run -d --name mapserver -v $(pwd):/maps:ro -p 1882:80 geodata/mapserver
 ```
+
 and use a url like `"url": "http://localhost:1882/?map=/maps/my-app.map",`
 
-
 Other useful map servers include Geoserver, a somewhat larger image but fully featured.
+
 ```
 docker run --name geoserver -d -v ${PWD}:/var/local/geoserver -p 1885:8080 oscarfonts/geoserver
 ```
@@ -806,7 +801,6 @@ You can then add a new WMS Base layer by injecting a message like
         },
         "wms": true                  // set to true for WMS type mapserver
     }}}
-
 
 ---
 

--- a/worldmap/worldmap.js
+++ b/worldmap/worldmap.js
@@ -2547,11 +2547,11 @@ function doCommand(cmd) {
         try { coords.removeFrom(map); }
         catch(e) {}
         var opts = {gps:false, gpsLong:false, utm:false, utmref:false, position:"bottomleft"}
-        if (cmd.coords == "deg") { opts.gps = true; }
-        if (cmd.coords == "dms") { opts.gpsLong = true; }
-        if (cmd.coords == "utm") { opts.utm = true; }
-        if (cmd.coords == "mgrs") { opts.utmref = true; }
-        if (cmd.coords == "qth") { opts.qth = true; }
+        if (cmd.coords.includes("deg")) { opts.gps = true; }
+        if (cmd.coords.includes("dms")) { opts.gpsLong = true; }
+        if (cmd.coords.includes("utm")) { opts.utm = true; }
+        if (cmd.coords.includes("mgrs")) { opts.utmref = true; }
+        if (cmd.coords.includes("qth")) { opts.qth = true; }
         coords.options = opts;
         coords.addTo(map);
     }


### PR DESCRIPTION
The original mouse coordinates plugin allows the display of multiple coordinate formats. It has been changed to use include() instead of == to enable comma-separated coordinate formats. The README did not list all available options; I have added the missing formats.

modified: README.md
modified: worldmap/worldmap.js