### PR TITLE
Multiple coordinate formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Optional properties for **msg.payload.command** include
  - **panit** - auto pan to the latest marker updated.  - `{"command":{"panit":true}}`
  - **zoomlock** - locks the zoom control to the current value and removes zoom control - `{"command":{"zoomlock":true}}`
  - **hiderightclick** - disables the right click that allows adding or deleting points on the map - `{"command":{"hiderightclick":true}}`
- - **coords** - turns on and off a display of the current mouse co-ordinates. Values can be "deg", "dms", or "none" (default). - `{"command":{"coords":"deg"}}`
+ - **coords** - turns on and off a display of the current mouse co-ordinates. Values can be "deg", "dms", "utm", "mgrs", "qth" or "none" (default). - `{"command":{"coords":"deg"}}` , `{"command":{"coords":"deg,dms,utm"}}`
  - **showruler** - turns on and off a display of the ruler control. Values can be "true" or "false". - `{"command": {"ruler": {"showruler": true}}}`
  - **button** - if supplied with a `name` and `icon` property - adds a button to provide user input - sends
  a msg `{"action":"button", "name":"the_button_name"}` to the worldmap in node. If supplied with a `name` property only, it will remove the button. Optional `position` property can be 'bottomright', 'bottomleft', 'topleft' or 'topright' (default). button can also be an array of button objects.

--- a/worldmap/worldmap.js
+++ b/worldmap/worldmap.js
@@ -2558,11 +2558,11 @@ function doCommand(cmd) {
         try { coords.removeFrom(map); }
         catch(e) {}
         var opts = {gps:false, gpsLong:false, utm:false, utmref:false, position:"bottomleft"}
-        if (cmd.coords == "deg") { opts.gps = true; }
-        if (cmd.coords == "dms") { opts.gpsLong = true; }
-        if (cmd.coords == "utm") { opts.utm = true; }
-        if (cmd.coords == "mgrs") { opts.utmref = true; }
-        if (cmd.coords == "qth") { opts.qth = true; }
+        if (cmd.coords.includes("deg")) { opts.gps = true; }
+        if (cmd.coords.includes("dms")) { opts.gpsLong = true; }
+        if (cmd.coords.includes("utm")) { opts.utm = true; }
+        if (cmd.coords.includes("mgrs")) { opts.utmref = true; }
+        if (cmd.coords.includes("qth")) { opts.qth = true; }
         coords.options = opts;
         coords.addTo(map);
     }


### PR DESCRIPTION
The original mouse coordinate plugin allows multiple coordinate formats to be displayed. A comma-separated option has been added to enable this feature while maintaining backward compatibility.

(It seems I made a few pull requests while you were updating the README, which caused merge conflicts. This is a clean PR.)