### PR TITLE
MouseCoordinates - Restore `ddmm.mmmm` Format in `gpsLong` option and add an example

### DIFF
--- a/examples/MouseCoordinates.json
+++ b/examples/MouseCoordinates.json
@@ -1,0 +1,159 @@
+[
+    {
+        "id": "c643e022.1816c",
+        "type": "worldmap",
+        "z": "f6f2187d.f17ca8",
+        "name": "",
+        "lat": "30",
+        "lon": "0",
+        "zoom": "3",
+        "layer": "OSMG",
+        "cluster": "",
+        "maxage": "",
+        "usermenu": "show",
+        "layers": "show",
+        "panit": "false",
+        "panlock": "false",
+        "zoomlock": "false",
+        "hiderightclick": "false",
+        "coords": "deg",
+        "showgrid": "false",
+        "showruler": "false",
+        "allowFileDrop": "false",
+        "path": "worldmap",
+        "overlist": "DR,CO,RA,DN",
+        "maplist": "OSMG,OSMH,EsriS",
+        "mapname": "",
+        "mapurl": "",
+        "mapopt": "",
+        "mapwms": false,
+        "x": 1480,
+        "y": 700,
+        "wires": []
+    },
+    {
+        "id": "32d7cc4d4db67f66",
+        "type": "worldmap in",
+        "z": "f6f2187d.f17ca8",
+        "name": "",
+        "path": "/worldmap",
+        "events": "connect,disconnect,point,layer,bounds,files,draw,other",
+        "x": 900,
+        "y": 700,
+        "wires": [
+            [
+                "32a2b83008623990"
+            ]
+        ]
+    },
+    {
+        "id": "32a2b83008623990",
+        "type": "debug",
+        "z": "f6f2187d.f17ca8",
+        "name": "debug 14",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1060,
+        "y": 620,
+        "wires": []
+    },
+    {
+        "id": "34ad8daae96efd3e",
+        "type": "debug",
+        "z": "f6f2187d.f17ca8",
+        "name": "debug 15",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1480,
+        "y": 620,
+        "wires": []
+    },
+    {
+        "id": "4cf111b68098072d",
+        "type": "inject",
+        "z": "f6f2187d.f17ca8",
+        "name": "Deg + DMS + UTM",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "0.5",
+        "topic": "",
+        "payload": " {\"command\": {\"coords\" : \"deg,dms,utm\"}}",
+        "payloadType": "json",
+        "x": 1270,
+        "y": 700,
+        "wires": [
+            [
+                "c643e022.1816c",
+                "34ad8daae96efd3e"
+            ]
+        ]
+    },
+    {
+        "id": "610e6795facbc3b7",
+        "type": "inject",
+        "z": "f6f2187d.f17ca8",
+        "name": "Deg + UTM",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "0.5",
+        "topic": "",
+        "payload": " {\"command\": {\"coords\" : \"deg,utm\"}}",
+        "payloadType": "json",
+        "x": 1250,
+        "y": 760,
+        "wires": [
+            [
+                "c643e022.1816c",
+                "34ad8daae96efd3e"
+            ]
+        ]
+    },
+    {
+        "id": "9a238dc42949cb17",
+        "type": "inject",
+        "z": "f6f2187d.f17ca8",
+        "name": "None",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "0.5",
+        "topic": "",
+        "payload": " {\"command\": {\"coords\" : \"\"}}",
+        "payloadType": "json",
+        "x": 1230,
+        "y": 820,
+        "wires": [
+            [
+                "c643e022.1816c",
+                "34ad8daae96efd3e"
+            ]
+        ]
+    }
+]

--- a/worldmap/leaflet/leaflet.mousecoordinate.js
+++ b/worldmap/leaflet/leaflet.mousecoordinate.js
@@ -45,10 +45,10 @@ L.Control.mouseCoordinate  = L.Control.extend({
             content += "<tr><td>Lat, Lon&nbsp;</td><td>" + dLat + ", " + dLng +"</td></tr>";
         }
         if (this.options.gpsLong) {
-            // var gpsMinuten = this._geo2geodeziminuten(gps);
-            // content += "<tr><td>"+ gpsMinuten.NS + " " + gpsMinuten.latgrad + "&deg; "+ gpsMinuten.latminuten+"</td><td> " + gpsMinuten.WE + " "+ gpsMinuten.lnggrad +"&deg; "+ gpsMinuten.lngminuten +"</td></tr>";
+            var gpsMinuten = this._geo2geodeziminuten(gps);
+            content += "<tr><td>ddmm.mm</td><td>"+ gpsMinuten.NS + " " + gpsMinuten.latgrad + "&deg; "+ gpsMinuten.latminuten+"</td><td> " + gpsMinuten.WE + " "+ gpsMinuten.lnggrad +"&deg; "+ gpsMinuten.lngminuten +"</td></tr>";
             var gpsMinutenSekunden = this._geo2gradminutensekunden(gps);
-            content += "<tr><td>"+ gpsMinutenSekunden.NS + " " + gpsMinutenSekunden.latgrad + "&deg; "+ gpsMinutenSekunden.latminuten + "&prime; "+ gpsMinutenSekunden.latsekunden+"&Prime;</td><td> " + gpsMinutenSekunden.WE + " "+ gpsMinutenSekunden.lnggrad +"&deg; "+ gpsMinutenSekunden.lngminuten + "&prime; "+ gpsMinutenSekunden.lngsekunden+"&Prime;</td></tr>";
+            content += "<tr><td>ddmmss.ss</td><td>"+ gpsMinutenSekunden.NS + " " + gpsMinutenSekunden.latgrad + "&deg; "+ gpsMinutenSekunden.latminuten + "&prime; "+ gpsMinutenSekunden.latsekunden+"&Prime;</td><td> " + gpsMinutenSekunden.WE + " "+ gpsMinutenSekunden.lnggrad +"&deg; "+ gpsMinutenSekunden.lngminuten + "&prime; "+ gpsMinutenSekunden.lngsekunden+"&Prime;</td></tr>";
         }
         if (this.options.utm) {
             var utm = UTM.fromLatLng(gps);


### PR DESCRIPTION
The original plugin's `gpsLong` option supported displaying coordinates in both the `ddmm.mmmm` (degrees and minutes) and `ddmmss.ss` (degrees, minutes, and seconds) formats. However, the ddmm.mmmm format was removed for some reason, even though it is widely used. This update restores the `ddmm.mmmm` format for broader usability.

Additionally, I’ve added a new `MouseCoordinate` example file to demonstrate this functionality.