### PR TITLE
Edge SIDC - Add option to control edgeEnabled flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Optional properties for **msg.payload.command** include
  - **trackme** - Turns on/off the browser self locating. Boolean false = off, true = cyan circle showing accuracy error, or an object like `{"command":{"trackme":{"name":"Dave","icon":"car","iconColor":"blue","layer":"mytrack","accuracy":false}}}`. Usual marker options can be applied. 
  - **showmenu** - Show or hide the display of the hamberger menu control in the top right . Values can be "show" or "hide". - `{"command":{"showmenu": "hide"}}`
  - **showlayers** - Show or hide the display of selectable layers. Does not control the display of an individual layer, rather a users ability to interact with them. Values can be "show" or "hide". - `{"command":{"showlayers": "hide"}}`
+ - **edgeenabled** - Show or hide small sidc icons around edge of map for things just outside of view. Values can be true or false (default is true). - `{"command":{"edgeenabled": false}}`
 
 #### To switch layer, move map and zoom
 

--- a/examples/sidcEdgeIcon.json
+++ b/examples/sidcEdgeIcon.json
@@ -1,0 +1,158 @@
+[
+    {
+        "id": "3e0aaa7abbebfb76",
+        "type": "inject",
+        "z": "5ffb0f06dfc7e99e",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "topic": "",
+        "payload": "",
+        "payloadType": "str",
+        "x": 630,
+        "y": 440,
+        "wires": [
+            [
+                "1b0f9c61acc853d8"
+            ]
+        ]
+    },
+    {
+        "id": "1b0f9c61acc853d8",
+        "type": "function",
+        "z": "5ffb0f06dfc7e99e",
+        "name": "Add SIDC object to map",
+        "func": "msg.payload = {\n    \"name\": \"Emergency Medical Operation\",\n    \"lat\": 51.05,\n    \"lon\": -1.35,\n    \"SIDC\": \"ENOPA-------\",\n    \"options\": { \"fillOpacity\": 0.8, \"additionalInformation\": \"Extra info\" }\n}\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 840,
+        "y": 440,
+        "wires": [
+            [
+                "e12fb3cdb87416ed"
+            ]
+        ]
+    },
+    {
+        "id": "cbeb8daf52cb3088",
+        "type": "comment",
+        "z": "5ffb0f06dfc7e99e",
+        "name": "Simple map - click inject to send point to map.",
+        "info": "Adds a map at http://(your-server-ip):1880/worldmap. \n\nThe `function` node creates a SIDC object with some basic properties required to add to a map.",
+        "x": 830,
+        "y": 380,
+        "wires": []
+    },
+    {
+        "id": "e12fb3cdb87416ed",
+        "type": "worldmap",
+        "z": "5ffb0f06dfc7e99e",
+        "name": "",
+        "lat": "",
+        "lon": "",
+        "zoom": "",
+        "layer": "OSMG",
+        "cluster": "",
+        "maxage": "",
+        "usermenu": "show",
+        "layers": "show",
+        "panit": "false",
+        "panlock": "false",
+        "zoomlock": "false",
+        "hiderightclick": "false",
+        "coords": "none",
+        "showgrid": "false",
+        "showruler": "true",
+        "allowFileDrop": "false",
+        "path": "/worldmap",
+        "overlist": "DR,CO,RA,DN,HM",
+        "maplist": "OSMG,OSMC,EsriC,EsriS,EsriT,EsriO,EsriDG,NatGeo,UKOS,OpTop",
+        "mapname": "",
+        "mapurl": "",
+        "mapopt": "",
+        "mapwms": false,
+        "x": 1060,
+        "y": 440,
+        "wires": []
+    },
+    {
+        "id": "c5da3e3241f2bfcc",
+        "type": "inject",
+        "z": "5ffb0f06dfc7e99e",
+        "name": "Disable Edge Icon",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "{\"command\" : {\"sidcEdgeIcon\" : false}}",
+        "payloadType": "json",
+        "x": 850,
+        "y": 480,
+        "wires": [
+            [
+                "e12fb3cdb87416ed"
+            ]
+        ]
+    },
+    {
+        "id": "017d2569f2c8a046",
+        "type": "inject",
+        "z": "5ffb0f06dfc7e99e",
+        "name": "Enable Edge Icon",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "{\"command\" : {\"sidcEdgeIcon\" : true}}",
+        "payloadType": "json",
+        "x": 850,
+        "y": 520,
+        "wires": [
+            [
+                "e12fb3cdb87416ed"
+            ]
+        ]
+    },
+    {
+        "id": "a6cfecb5747ff649",
+        "type": "inject",
+        "z": "5ffb0f06dfc7e99e",
+        "name": "Error Edge Icon (=1)",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "{\"command\" : {\"sidcEdgeIcon\" :  1 }}",
+        "payloadType": "json",
+        "x": 850,
+        "y": 560,
+        "wires": [
+            [
+                "e12fb3cdb87416ed"
+            ]
+        ]
+    }
+]

--- a/worldmap/worldmap.js
+++ b/worldmap/worldmap.js
@@ -3087,8 +3087,12 @@ function doCommand(cmd) {
         document.getElementById("maxage").value = cmd.maxage;
         setMaxAge();
     }
-    if (cmd.hasOwnProperty("edgeenabled")) {
-        edgeEnabled = cmd.edgeenabled;
+    if (cmd.hasOwnProperty("sidcEdgeIcon")) {
+        if (typeof cmd.sidcEdgeIcon === 'boolean') {
+            edgeEnabled = cmd.sidcEdgeIcon;
+        } else {
+            console.log("ERR - invalid sidcEdgeIcon command: ", cmd.sidcEdgeIcon);
+        }
     }
     // Replace heatmap layer with new array (and optionally options)
     if (cmd.hasOwnProperty("heatmap") && heat) {

--- a/worldmap/worldmap.js
+++ b/worldmap/worldmap.js
@@ -438,9 +438,9 @@ var Lgrid = L.latlngGraticule({
 // Add small sidc icons around edge of map for things just outside of view
 // This function based heavily on Game Aware code from Måns Beckman
 // Copyright (c) 2013 Måns Beckman, All rights reserved.
-var edgeAware = function() {
+var edgeAware = function () {
+    map.removeLayer(edgeLayer);
     if (!edgeEnabled) { return; }
-    map.removeLayer(edgeLayer)
     edgeLayer = new L.layerGroup();
     var mapBounds = map.getBounds();
     var mapBoundsCenter = mapBounds.getCenter();
@@ -3065,6 +3065,9 @@ function doCommand(cmd) {
     if (cmd.hasOwnProperty("maxage")) {
         document.getElementById("maxage").value = cmd.maxage;
         setMaxAge();
+    }
+    if (cmd.hasOwnProperty("edgeenabled")) {
+        edgeEnabled = cmd.edgeenabled;
     }
     // Replace heatmap layer with new array (and optionally options)
     if (cmd.hasOwnProperty("heatmap") && heat) {


### PR DESCRIPTION
`edgeEnabled` Adds small sidc icons around edge of map for things with SIDC markers just outside of view.
This option was set to true by default with no way to remove it, added enable disable command.